### PR TITLE
fix: pause ad rendering when app goes to background (fix GPU crash on…

### DIFF
--- a/android/src/main/kotlin/com/tqc/ads/flutter_admob_native_ads/FlutterAdmobNativeAdsPlugin.kt
+++ b/android/src/main/kotlin/com/tqc/ads/flutter_admob_native_ads/FlutterAdmobNativeAdsPlugin.kt
@@ -57,6 +57,10 @@ class FlutterAdmobNativeAdsPlugin : FlutterPlugin, MethodCallHandler {
         private val bannerAdCallbacks = mutableMapOf<String, (AdView) -> Unit>()
         private val loadedBannerAds = mutableMapOf<String, AdView>()
 
+        // Maps to track active ad views for pause/resume rendering (fix GPU crashes on MediaTek)
+        private val activeNativeAdViews = mutableMapOf<String, android.view.View>()
+        private val activeBannerAdViews = mutableMapOf<String, android.view.View>()
+
         fun getInstance(): FlutterAdmobNativeAdsPlugin? = instance
 
         fun getAdLoaders(): Map<String, NativeAdLoader> = adLoaders
@@ -124,6 +128,23 @@ class FlutterAdmobNativeAdsPlugin : FlutterPlugin, MethodCallHandler {
             bannerAdLoaders.values.forEach { it.destroy() }
             bannerAdLoaders.clear()
             loadedBannerAds.clear()
+        }
+
+        // Methods for tracking active ad views (pause/resume rendering)
+        fun registerActiveNativeAdView(controllerId: String, view: android.view.View) {
+            activeNativeAdViews[controllerId] = view
+        }
+
+        fun unregisterActiveNativeAdView(controllerId: String) {
+            activeNativeAdViews.remove(controllerId)
+        }
+
+        fun registerActiveBannerAdView(controllerId: String, view: android.view.View) {
+            activeBannerAdViews[controllerId] = view
+        }
+
+        fun unregisterActiveBannerAdView(controllerId: String) {
+            activeBannerAdViews.remove(controllerId)
         }
     }
 
@@ -293,6 +314,8 @@ class FlutterAdmobNativeAdsPlugin : FlutterPlugin, MethodCallHandler {
             "loadBannerAd" -> handleLoadBannerAd(call, result)
             "reloadBannerAd" -> handleReloadBannerAd(call, result)
             "disposeBannerAd" -> handleDisposeBannerAd(call, result)
+            "pauseAdRendering" -> handlePauseAdRendering(call, result)
+            "resumeAdRendering" -> handleResumeAdRendering(call, result)
             "getPlatformVersion" -> result.success("Android ${android.os.Build.VERSION.RELEASE}")
             else -> result.notImplemented()
         }
@@ -464,6 +487,52 @@ class FlutterAdmobNativeAdsPlugin : FlutterPlugin, MethodCallHandler {
         getBannerAdLoaders()[controllerId]?.destroy()
         removeBannerAdLoader(controllerId)
         clearBannerAdCallback(controllerId)
+
+        result.success(null)
+    }
+
+    private fun handlePauseAdRendering(call: MethodCall, result: Result) {
+        val controllerId = call.argument<String>("controllerId")
+
+        if (controllerId.isNullOrEmpty()) {
+            result.error("INVALID_ARGS", "controllerId is required", null)
+            return
+        }
+
+        // Pause native ad view rendering
+        activeNativeAdViews[controllerId]?.let { view ->
+            view.visibility = android.view.View.INVISIBLE
+            Log.d(TAG, "Paused rendering for native ad controller: $controllerId")
+        }
+
+        // Pause banner ad view rendering
+        activeBannerAdViews[controllerId]?.let { view ->
+            view.visibility = android.view.View.INVISIBLE
+            Log.d(TAG, "Paused rendering for banner ad controller: $controllerId")
+        }
+
+        result.success(null)
+    }
+
+    private fun handleResumeAdRendering(call: MethodCall, result: Result) {
+        val controllerId = call.argument<String>("controllerId")
+
+        if (controllerId.isNullOrEmpty()) {
+            result.error("INVALID_ARGS", "controllerId is required", null)
+            return
+        }
+
+        // Resume native ad view rendering
+        activeNativeAdViews[controllerId]?.let { view ->
+            view.visibility = android.view.View.VISIBLE
+            Log.d(TAG, "Resumed rendering for native ad controller: $controllerId")
+        }
+
+        // Resume banner ad view rendering
+        activeBannerAdViews[controllerId]?.let { view ->
+            view.visibility = android.view.View.VISIBLE
+            Log.d(TAG, "Resumed rendering for banner ad controller: $controllerId")
+        }
 
         result.success(null)
     }

--- a/android/src/main/kotlin/com/tqc/ads/flutter_admob_native_ads/banner/BannerAdPlatformView.kt
+++ b/android/src/main/kotlin/com/tqc/ads/flutter_admob_native_ads/banner/BannerAdPlatformView.kt
@@ -98,6 +98,12 @@ class BannerAdPlatformView(
             FrameLayout.LayoutParams.MATCH_PARENT
         ))
 
+        // Register this view for pause/resume rendering (fix GPU crashes on MediaTek)
+        controllerId?.let { id ->
+            FlutterAdmobNativeAdsPlugin.registerActiveBannerAdView(id, bannerView)
+            log("Registered banner view for pause/resume rendering")
+        }
+
         log("Banner view added to container")
     }
 
@@ -117,9 +123,14 @@ class BannerAdPlatformView(
     override fun dispose() {
         log("Disposing banner platform view")
 
+        // Unregister from pause/resume tracking
+        controllerId?.let { id: String ->
+            FlutterAdmobNativeAdsPlugin.unregisterActiveBannerAdView(id)
+        }
+
         // Unregister callback
-        controllerId?.let {
-            FlutterAdmobNativeAdsPlugin.getInstance()?.unregisterBannerAdCallback(it)
+        controllerId?.let { id: String ->
+            FlutterAdmobNativeAdsPlugin.getInstance()?.unregisterBannerAdCallback(id)
         }
 
         // Remove view from container but don't destroy the ad

--- a/android/src/main/kotlin/com/tqc/ads/flutter_admob_native_ads/platform_view/NativeAdPlatformView.kt
+++ b/android/src/main/kotlin/com/tqc/ads/flutter_admob_native_ads/platform_view/NativeAdPlatformView.kt
@@ -102,6 +102,14 @@ class NativeAdPlatformView(
         if (nativeAdView?.parent == null) {
             container.addView(nativeAdView)
         }
+
+        // Register this view for pause/resume rendering (fix GPU crashes on MediaTek)
+        controllerId?.let { id ->
+            nativeAdView?.let { view ->
+                FlutterAdmobNativeAdsPlugin.registerActiveNativeAdView(id, view)
+                log("Registered view for pause/resume rendering")
+            }
+        }
     }
 
     private fun populateAdView(nativeAd: NativeAd) {
@@ -188,9 +196,14 @@ class NativeAdPlatformView(
     override fun dispose() {
         log("Disposing platform view")
 
+        // Unregister from pause/resume tracking
+        controllerId?.let { id: String ->
+            FlutterAdmobNativeAdsPlugin.unregisterActiveNativeAdView(id)
+        }
+
         // Unregister callback from plugin
-        controllerId?.let {
-            FlutterAdmobNativeAdsPlugin.getInstance()?.unregisterAdLoadedCallback(it)
+        controllerId?.let { id: String ->
+            FlutterAdmobNativeAdsPlugin.getInstance()?.unregisterAdLoadedCallback(id)
         }
 
         nativeAdView = null

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -116,7 +116,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.4+4"
+    version: "1.0.4+5"
   flutter_driver:
     dependency: transitive
     description: flutter

--- a/ios/Classes/BannerAd/BannerAdPlatformView.swift
+++ b/ios/Classes/BannerAd/BannerAdPlatformView.swift
@@ -69,6 +69,12 @@ class BannerAdPlatformView: NSObject, FlutterPlatformView {
             view.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
             view.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
         ])
+
+        // Register this view for pause/resume rendering (fix GPU crashes)
+        if let controllerId = controllerId {
+            FlutterAdmobNativeAdsPlugin.shared()?.registerActiveBannerAdView(controllerId: controllerId, view: view)
+            log("Registered banner view for pause/resume rendering")
+        }
     }
 
     private func log(_ message: String) {
@@ -78,6 +84,11 @@ class BannerAdPlatformView: NSObject, FlutterPlatformView {
     }
 
     deinit {
+        // Unregister from pause/resume tracking
+        if let controllerId = controllerId {
+            FlutterAdmobNativeAdsPlugin.shared()?.unregisterActiveBannerAdView(controllerId: controllerId)
+        }
+
         if let controllerId = controllerId {
             FlutterAdmobNativeAdsPlugin.shared()?.unregisterBannerAdCallback(controllerId: controllerId)
         }

--- a/ios/Classes/PlatformView/NativeAdPlatformView.swift
+++ b/ios/Classes/PlatformView/NativeAdPlatformView.swift
@@ -93,6 +93,12 @@ class NativeAdPlatformView: NSObject, FlutterPlatformView {
                 adView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
             ])
         }
+
+        // Register this view for pause/resume rendering (fix GPU crashes)
+        if let controllerId = controllerId {
+            FlutterAdmobNativeAdsPlugin.shared()?.registerActiveNativeAdView(controllerId: controllerId, view: adView)
+            log("Registered view for pause/resume rendering")
+        }
     }
 
     private func populateAdView(_ nativeAd: GADNativeAd) {
@@ -180,6 +186,11 @@ class NativeAdPlatformView: NSObject, FlutterPlatformView {
     }
 
     deinit {
+        // Unregister from pause/resume tracking
+        if let controllerId = controllerId {
+            FlutterAdmobNativeAdsPlugin.shared()?.unregisterActiveNativeAdView(controllerId: controllerId)
+        }
+
         // Unregister callback from plugin when view is deallocated
         if let controllerId = controllerId {
             FlutterAdmobNativeAdsPlugin.shared()?.unregisterAdLoadedCallback(controllerId: controllerId)

--- a/ios/Classes/Plugin/FlutterAdmobNativeAdsPlugin.swift
+++ b/ios/Classes/Plugin/FlutterAdmobNativeAdsPlugin.swift
@@ -53,6 +53,12 @@ public class FlutterAdmobNativeAdsPlugin: NSObject, FlutterPlugin {
     /// Cache of loaded banner ads (to handle race condition between ad load and platform view creation)
     private var loadedBannerAds: [String: GADBannerView] = [:]
 
+    /// Maps to track active native ad views for pause/resume rendering (fix GPU crashes)
+    private var activeNativeAdViews: [String: UIView] = [:]
+
+    /// Maps to track active banner ad views for pause/resume rendering (fix GPU crashes)
+    private var activeBannerAdViews: [String: UIView] = [:]
+
     /// Gets the preloaded native ad for the given controller ID.
     /// Returns nil if no ad is loaded for the controller or if the ad has expired.
     public func getPreloadedAd(controllerId: String) -> GADNativeAd? {
@@ -117,6 +123,30 @@ public class FlutterAdmobNativeAdsPlugin: NSObject, FlutterPlugin {
     /// Unregisters the banner ad loaded callback for the given controller.
     public func unregisterBannerAdCallback(controllerId: String) {
         bannerAdCallbacks.removeValue(forKey: controllerId)
+    }
+
+    // MARK: - Active Ad View Tracking (Pause/Resume Rendering)
+
+    /// Registers an active native ad view for pause/resume rendering
+    public func registerActiveNativeAdView(controllerId: String, view: UIView) {
+        activeNativeAdViews[controllerId] = view
+        print("[FlutterAdmobNativeAds] Registered native ad view for pause/resume: \(controllerId)")
+    }
+
+    /// Unregisters an active native ad view
+    public func unregisterActiveNativeAdView(controllerId: String) {
+        activeNativeAdViews.removeValue(forKey: controllerId)
+    }
+
+    /// Registers an active banner ad view for pause/resume rendering
+    public func registerActiveBannerAdView(controllerId: String, view: UIView) {
+        activeBannerAdViews[controllerId] = view
+        print("[FlutterAdmobNativeAds] Registered banner ad view for pause/resume: \(controllerId)")
+    }
+
+    /// Unregisters an active banner ad view
+    public func unregisterActiveBannerAdView(controllerId: String) {
+        activeBannerAdViews.removeValue(forKey: controllerId)
     }
 
     public static func register(with registrar: FlutterPluginRegistrar) {
@@ -212,6 +242,10 @@ public class FlutterAdmobNativeAdsPlugin: NSObject, FlutterPlugin {
             handleReloadBannerAd(call, result: result)
         case "disposeBannerAd":
             handleDisposeBannerAd(call, result: result)
+        case "pauseAdRendering":
+            handlePauseAdRendering(call, result: result)
+        case "resumeAdRendering":
+            handleResumeAdRendering(call, result: result)
         case "getPlatformVersion":
             result("iOS \(UIDevice.current.systemVersion)")
         default:
@@ -473,6 +507,58 @@ public class FlutterAdmobNativeAdsPlugin: NSObject, FlutterPlugin {
         bannerAdLoaders.removeValue(forKey: controllerId)
         bannerAdCallbacks.removeValue(forKey: controllerId)
         loadedBannerAds.removeValue(forKey: controllerId)
+
+        result(nil)
+    }
+
+    private func handlePauseAdRendering(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let args = call.arguments as? [String: Any],
+              let controllerId = args["controllerId"] as? String else {
+            result(FlutterError(
+                code: "INVALID_ARGS",
+                message: "controllerId is required",
+                details: nil
+            ))
+            return
+        }
+
+        // Pause native ad view rendering by hiding it
+        if let view = activeNativeAdViews[controllerId] {
+            view.isHidden = true
+            print("[FlutterAdmobNativeAds] Paused rendering for native ad controller: \(controllerId)")
+        }
+
+        // Pause banner ad view rendering by hiding it
+        if let view = activeBannerAdViews[controllerId] {
+            view.isHidden = true
+            print("[FlutterAdmobNativeAds] Paused rendering for banner ad controller: \(controllerId)")
+        }
+
+        result(nil)
+    }
+
+    private func handleResumeAdRendering(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let args = call.arguments as? [String: Any],
+              let controllerId = args["controllerId"] as? String else {
+            result(FlutterError(
+                code: "INVALID_ARGS",
+                message: "controllerId is required",
+                details: nil
+            ))
+            return
+        }
+
+        // Resume native ad view rendering by showing it
+        if let view = activeNativeAdViews[controllerId] {
+            view.isHidden = false
+            print("[FlutterAdmobNativeAds] Resumed rendering for native ad controller: \(controllerId)")
+        }
+
+        // Resume banner ad view rendering by showing it
+        if let view = activeBannerAdViews[controllerId] {
+            view.isHidden = false
+            print("[FlutterAdmobNativeAds] Resumed rendering for banner ad controller: \(controllerId)")
+        }
 
         result(nil)
     }

--- a/lib/src/controllers/ad_controller_mixin.dart
+++ b/lib/src/controllers/ad_controller_mixin.dart
@@ -90,6 +90,9 @@ mixin AdControllerMixin<TState> {
   AppLifecycleManager? get lifecycleManager;
   set lifecycleManager(AppLifecycleManager? value);
 
+  /// Stream subscription for pause rendering events.
+  StreamSubscription<bool>? _pauseRenderingSubscription;
+
   NetworkConnectivityManager? get networkManager;
   set networkManager(NetworkConnectivityManager? value);
 
@@ -143,6 +146,13 @@ mixin AdControllerMixin<TState> {
     // Initialize lifecycle manager
     lifecycleManager!.initialize();
 
+    // Subscribe to pause rendering events to prevent GPU crashes
+    _pauseRenderingSubscription = lifecycleManager!.pauseRenderingStream.listen(
+      (shouldPause) {
+        _handlePauseRendering(shouldPause);
+      },
+    );
+
     // Initialize network manager asynchronously
     networkManager!.initialize().then((_) {
       // Create scheduler after network check completes
@@ -163,7 +173,17 @@ mixin AdControllerMixin<TState> {
   /// Initializes smart reload services when enableSmartReload is true.
   void initializeSmartReload() {
     // Reuse lifecycle manager from preload if available, otherwise create new
+    final isNewLifecycleManager = lifecycleManager == null;
     lifecycleManager ??= AppLifecycleManager()..initialize();
+
+    // Subscribe to pause rendering events if we created a new lifecycle manager
+    if (isNewLifecycleManager) {
+      _pauseRenderingSubscription = lifecycleManager!.pauseRenderingStream.listen(
+        (shouldPause) {
+          _handlePauseRendering(shouldPause);
+        },
+      );
+    }
 
     // Reuse network manager from preload if available, otherwise create new
     if (networkManager == null) {
@@ -477,11 +497,35 @@ mixin AdControllerMixin<TState> {
     await performReload();
   }
 
+  /// Handles pause rendering events from app lifecycle.
+  ///
+  /// When app goes to background (shouldPause=true), we pause ad rendering
+  /// to prevent GPU crashes on devices with buggy drivers (e.g., MediaTek).
+  /// When app returns to foreground (shouldPause=false), we resume rendering.
+  void _handlePauseRendering(bool shouldPause) {
+    if (isDisposed) return;
+
+    final methodName = shouldPause ? 'pauseAdRendering' : 'resumeAdRendering';
+
+    if (enableDebugLogs) {
+      debugPrint('[$controllerType] $methodName (app lifecycle: ${shouldPause ? "background" : "foreground"})');
+    }
+
+    channel.invokeMethod(methodName, {'controllerId': id}).catchError((e) {
+      if (enableDebugLogs) {
+        debugPrint('[$controllerType] $methodName error: $e');
+      }
+    });
+  }
+
   /// Disposes the controller and releases resources.
   Future<void> dispose() async {
     if (isDisposed) return;
 
     isDisposed = true;
+
+    // Cancel pause rendering subscription
+    _pauseRenderingSubscription?.cancel();
 
     // Dispose smart preload and reload services
     preloadScheduler?.dispose();

--- a/lib/src/services/app_lifecycle_manager.dart
+++ b/lib/src/services/app_lifecycle_manager.dart
@@ -28,6 +28,9 @@ class AppLifecycleManager with WidgetsBindingObserver {
   bool _isInForeground = true;
   final _foregroundController = StreamController<bool>.broadcast();
 
+  /// Stream controller for pause rendering events.
+  final _pauseRenderingController = StreamController<bool>.broadcast();
+
   /// Whether the app is currently in foreground (resumed state).
   ///
   /// Returns `true` when app is active and visible to user.
@@ -38,6 +41,13 @@ class AppLifecycleManager with WidgetsBindingObserver {
   ///
   /// Only emits when state actually changes (debounced).
   Stream<bool> get foregroundStream => _foregroundController.stream;
+
+  /// Stream that emits `true` when app should pause ad rendering (backgrounded),
+  /// `false` when ad rendering should resume (foreground).
+  ///
+  /// Used to prevent GPU crashes on devices with buggy drivers (e.g., MediaTek)
+  /// by hiding ad views when app goes to background.
+  Stream<bool> get pauseRenderingStream => _pauseRenderingController.stream;
 
   /// Initializes the lifecycle manager and starts monitoring app state.
   ///
@@ -58,6 +68,10 @@ class AppLifecycleManager with WidgetsBindingObserver {
     // Only emit when state actually changes
     if (wasInForeground != _isInForeground) {
       _foregroundController.add(_isInForeground);
+
+      // Also emit pause rendering event to prevent GPU crashes
+      // when app goes to background on devices with buggy drivers
+      _pauseRenderingController.add(!_isInForeground);
     }
   }
 
@@ -68,5 +82,6 @@ class AppLifecycleManager with WidgetsBindingObserver {
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     _foregroundController.close();
+    _pauseRenderingController.close();
   }
 }


### PR DESCRIPTION
… MediaTek)

- Add pauseRenderingStream to AppLifecycleManager
- Auto-invoke pauseAdRendering/resumeAdRendering on lifecycle changes
- Track active ad views in plugin (Android/iOS)
- Toggle visibility/hidden state when app background/foreground
- Register/unregister views in platform views

This fixes the eglMakeCurrent crash on MediaTek devices caused by invalid OpenGL context when ads continue rendering in background.